### PR TITLE
Add version & 0.5 -> 0.8 workarounds.

### DIFF
--- a/component-download-button.html
+++ b/component-download-button.html
@@ -38,7 +38,7 @@ Example:
 @status beta
 @homepage github.io
 -->
-<polymer-element name="component-download-button" attributes="label open component org">
+<polymer-element name="component-download-button" attributes="label open component org version">
 
 <template>
 
@@ -91,7 +91,7 @@ Example:
         <core-icon-button icon="close" on-tap="{{toggle}}"></core-icon-button>
       </core-toolbar>
       <paper-shadow z="2"></paper-shadow>
-      <component-download-view flex org="{{org}}" component="{{component}}"></component-download-view>
+      <component-download-view flex org="{{org}}" component="{{component}}" version="{{version}}"></component-download-view>
     </div>
   </core-overlay>
 
@@ -131,6 +131,14 @@ Example:
      * @type String
      */
     org: "Polymer",
+
+    /**
+     * Optional: Bower version to download.
+     * @attribute version
+     * @default '^0.5'
+     * @type String
+     */
+    version: "^0.5",
 
     toggle: function() {
       this.open = !this.open;

--- a/component-download-view.html
+++ b/component-download-view.html
@@ -35,7 +35,7 @@ Example:
 @status beta
 @homepage github.io
 -->
-<polymer-element name="component-download-view" attributes="component org">
+<polymer-element name="component-download-view" attributes="component org version">
 <template>
 
   <style>
@@ -70,6 +70,12 @@ Example:
       background-color: #0f9d58;
       color: white;
       fill: white;
+    }
+
+    .cta[disabled] {
+      background-color: #cccccc;
+      color: #444;
+      fill: #444;
     }
 
     code {
@@ -137,7 +143,7 @@ Example:
   <core-selector selected="{{selected}}">
   
     <section>
-      <paper-button class="cta" on-tap="{{downloadZIP}}">
+      <paper-button disabled class="cta" on-tap="{{downloadZIP}}">
         <core-icon icon="file-download"></core-icon>
         <span class="label">Download ZIP</span>
       </paper-button>
@@ -148,15 +154,18 @@ Example:
         </li>
       </ol>
       <div class="note">
+        <strong>ZIP file download is temporarily unavailable.</strong>
+        <!--
         <strong>Quick start</strong>. The ZIP file contains all dependencies for this component and is 
         a great way to get started. For easier management and version control, 
         we recommend using 
         <a href="http://polymer-project.org/docs/start/getting-the-code.html#using-bower">Bower</a> instead.
+        -->
       </div>
     </section>
     
     <section>
-      <code class="block">bower install {{org}}/{{component}}</code>
+      <code class="block">bower install {{org}}/{{component}}#{{version}}</code>
       <ol>
         <li>Run the command above from your project root</li>
         <li>Import the component by adding this to your HTML file:<br>
@@ -206,6 +215,13 @@ Example:
      * @type String
      */
     org: "Polymer",
+
+    /**
+     * Bower version. Required.
+     * @attribute version
+     * @type String
+     */
+    version: '',
 
     ready: function() {
       var s = parseInt(localStorage.getItem('polymer-download-pref'));


### PR DESCRIPTION
- Disable ZIP file download until we can get Bower zipper to support versioned downloads.
- Add version # and default to ^0.5 so all of the download buttons on the 0.5 part of the site provide the correct bower install commands.

@ebidel @robdodson @kevinpschaaf someone PTAL.